### PR TITLE
Extend or_else functions to allow raising closures

### DIFF
--- a/option/deprecated.mbt
+++ b/option/deprecated.mbt
@@ -51,7 +51,7 @@ pub fn[T] Option::or(self : T?, default : T) -> T {
 
 ///|
 #deprecated("use unwrap_or_else instead")
-pub fn[T] Option::or_else(self : T?, default : () -> T raise?) -> T raise? {
+pub fn[T] Option::or_else(self : T?, default : () -> T) -> T {
   match self {
     None => default()
     Some(t) => t

--- a/option/deprecated.mbt
+++ b/option/deprecated.mbt
@@ -51,7 +51,7 @@ pub fn[T] Option::or(self : T?, default : T) -> T {
 
 ///|
 #deprecated("use unwrap_or_else instead")
-pub fn[T] Option::or_else(self : T?, default : () -> T) -> T {
+pub fn[T] Option::or_else(self : T?, default : () -> T raise?) -> T raise? {
   match self {
     None => default()
     Some(t) => t

--- a/option/option.mbt
+++ b/option/option.mbt
@@ -80,7 +80,11 @@ test "map_or" {
 ///   let a = Some(5)
 ///   assert_eq(a.map_or_else(() => 3, x => x * 2), 10)
 /// ```
-pub fn[T, U] map_or_else(self : T?, default : () -> U, f : (T) -> U) -> U {
+pub fn[T, U] map_or_else(
+  self : T?,
+  default : () -> U raise?,
+  f : (T) -> U raise?
+) -> U raise? {
   match self {
     None => default()
     Some(x) => f(x)
@@ -212,7 +216,10 @@ test "unwrap_or" {
 /// Return the contained `Some` value or the provided default.
 ///
 /// Default is lazily evaluated
-pub fn[T] Option::unwrap_or_else(self : T?, default : () -> T) -> T {
+pub fn[T] Option::unwrap_or_else(
+  self : T?,
+  default : () -> T raise?
+) -> T raise? {
   match self {
     None => default()
     Some(t) => t

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -31,7 +31,7 @@ fn[T] Option::or(T?, T) -> T
 #deprecated
 fn[T : Default] Option::or_default(T?) -> T
 #deprecated
-fn[T] Option::or_else(T?, () -> T raise?) -> T raise?
+fn[T] Option::or_else(T?, () -> T) -> T
 fn[T, Err : Error] Option::or_error(T?, Err) -> T raise Err
 fn[T] Option::unwrap_or(T?, T) -> T
 fn[T : Default] Option::unwrap_or_default(T?) -> T

--- a/option/option.mbti
+++ b/option/option.mbti
@@ -25,17 +25,17 @@ fn[T] Option::is_empty(T?) -> Bool
 fn[T] Option::iter(T?) -> Iter[T]
 fn[T, U] Option::map(T?, (T) -> U) -> U?
 fn[T, U] Option::map_or(T?, U, (T) -> U) -> U
-fn[T, U] Option::map_or_else(T?, () -> U, (T) -> U) -> U
+fn[T, U] Option::map_or_else(T?, () -> U raise?, (T) -> U raise?) -> U raise?
 #deprecated
 fn[T] Option::or(T?, T) -> T
 #deprecated
 fn[T : Default] Option::or_default(T?) -> T
 #deprecated
-fn[T] Option::or_else(T?, () -> T) -> T
+fn[T] Option::or_else(T?, () -> T raise?) -> T raise?
 fn[T, Err : Error] Option::or_error(T?, Err) -> T raise Err
 fn[T] Option::unwrap_or(T?, T) -> T
 fn[T : Default] Option::unwrap_or_default(T?) -> T
-fn[T] Option::unwrap_or_else(T?, () -> T) -> T
+fn[T] Option::unwrap_or_else(T?, () -> T raise?) -> T raise?
 impl[X : Compare] Compare for X?
 impl[X] Default for X?
 impl[X : @quickcheck.Arbitrary] @quickcheck.Arbitrary for X?

--- a/result/result.mbt
+++ b/result/result.mbt
@@ -170,7 +170,7 @@ test "or" {
 ///   let y = x.or_else(() => { 0 })
 ///   assert_eq(y, 6)
 /// ```
-pub fn[T, E] or_else(self : Result[T, E], default : () -> T) -> T {
+pub fn[T, E] or_else(self : Result[T, E], default : () -> T raise?) -> T raise? {
   match self {
     Ok(value) => value
     Err(_) => default()

--- a/result/result.mbti
+++ b/result/result.mbti
@@ -27,7 +27,7 @@ fn[T, E] Result::is_ok(Self[T, E]) -> Bool
 fn[T, E, U] Result::map(Self[T, E], (T) -> U) -> Self[U, E]
 fn[T, E, F] Result::map_err(Self[T, E], (E) -> F) -> Self[T, F]
 fn[T, E] Result::or(Self[T, E], T) -> T
-fn[T, E] Result::or_else(Self[T, E], () -> T) -> T
+fn[T, E] Result::or_else(Self[T, E], () -> T raise?) -> T raise?
 fn[T, E] Result::to_option(Self[T, E]) -> T?
 fn[T, E] Result::unwrap(Self[T, E]) -> T
 fn[T, E] Result::unwrap_err(Self[T, E]) -> E


### PR DESCRIPTION
## Summary
- allow `Option::map_or_else`, `Option::unwrap_or_else`, deprecated `Option::or_else`, and `Result::or_else` to accept callbacks that may raise errors
- update generated interfaces

## Testing
- `moon info`
- `moon check`
- `moon test`


------
https://chatgpt.com/codex/tasks/task_e_686b6e228d98833197207a89780e7c66